### PR TITLE
Add CSS support for select form fields

### DIFF
--- a/sass/srobo/atoms/forms.scss
+++ b/sass/srobo/atoms/forms.scss
@@ -1,11 +1,14 @@
 .form {
-  input {
-    &[type='email'], &[type='text'] {
-      border: 1px solid $sr-dark-grey;
-      border-radius: 3px;
-      font-size: $charlie;
-      padding: 12px;
-    }
+
+  input[type='email'], input[type='text'], select {
+    border: 1px solid $sr-dark-grey;
+    border-radius: 3px;
+    font-size: $charlie;
+    padding: 12px;
+    background: white;
+  }
+
+  input, select {
 
     &[type='submit'] {
       margin-right: 0;
@@ -38,7 +41,7 @@
   }
 }
 
-input.full-width {
+input.full-width, select.full-width {
   width: 100%;
 }
 


### PR DESCRIPTION
Select form fields currently show their default browser view, change them
to look like text fields, so they can be used in forms too.
