### PR TITLE
Simplify adding CSS in mobile- and desktop-only scenarios

### DIFF
--- a/sass/srobo/variables/responsive.scss
+++ b/sass/srobo/variables/responsive.scss
@@ -12,16 +12,26 @@ $breakpoints: (
   }
 }
 
-.desktop-only {
-  display: none;
+@mixin desktop-only {
+  @media (min-width: #{map-get($breakpoints, medium)}) {
+    @content;
+  }
+}
 
-  @include media-query(medium) {
-    display: inline;
+@mixin mobile-only {
+  @media (max-width: #{map-get($breakpoints, medium)}) {
+    @content;
+  }
+}
+
+.desktop-only {
+  @include mobile-only {
+    display: none;
   }
 }
 
 .mobile-only {
-  @include media-query(medium) {
+  @include desktop-only {
     display: none;
   }
 }


### PR DESCRIPTION
Previously it was only possible to easily filter for values of at least a given breakpoint, and even then the names didn't match up to our common CSS classes for use-cases. This introduces mixins which match those CSS classes, allowing for filtering in either direction, and the reimplements those CSS classes in terms of the new filters to ensure consistency.

As a side-effect this also makes it possible for desktop-only things to have a `display` of something other than `inline` when present, as we no longer need to assign a value in such cases (due to only applying the "hide" case when needed).

Demo of what this enables: https://github.com/srobo/competition-website/pull/47/files